### PR TITLE
Fix import schedule time validation

### DIFF
--- a/app/Exports/ExampleScheduleExport.php
+++ b/app/Exports/ExampleScheduleExport.php
@@ -6,8 +6,9 @@ use App\Models\Schedule;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Illuminate\Contracts\View\View;
 use Maatwebsite\Excel\Concerns\FromView;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
 
-class ExampleScheduleExport implements FromView
+class ExampleScheduleExport implements FromView, ShouldAutoSize
 {
     public function view(): View
     {

--- a/app/Exports/ScheduleExport.php
+++ b/app/Exports/ScheduleExport.php
@@ -6,8 +6,9 @@ use App\Models\Schedule;
 use Maatwebsite\Excel\Concerns\FromCollection;
 use Illuminate\Contracts\View\View;
 use Maatwebsite\Excel\Concerns\FromView;
+use Maatwebsite\Excel\Concerns\ShouldAutoSize;
 
-class ScheduleExport implements FromView
+class ScheduleExport implements FromView, ShouldAutoSize
 {
     function __construct($user_id, $child_id) {
         $this->user_id = $user_id;

--- a/app/Http/Controllers/Admin/ChildCrudController.php
+++ b/app/Http/Controllers/Admin/ChildCrudController.php
@@ -190,7 +190,7 @@ class ChildCrudController extends CrudController
     
             // show a success message
             \Alert::success('Muat naik jadual berjaya!')->flash();
-            return \Redirect::to($this->crud->route);
+            return \Redirect::to('/app/schedule');
         }
         \Alert::error('Muat naik jadual gagal!')->flash();
         return \Redirect::to($this->crud->route.'/'.$id.'/schedule');

--- a/app/Imports/ScheduleImport.php
+++ b/app/Imports/ScheduleImport.php
@@ -16,14 +16,30 @@ class ScheduleImport implements ToModel, WithHeadingRow
         $this->child_id = $child_id;
     }
 
+    public function toTime($time){
+
+        if($time <= 1 && $time >= 0){
+            $hours = floor($time * 24); 
+            $minute_fraction = ($time * 24) - $hours;
+            $minutes = $minute_fraction * 60; 
+            $toTime = $hours.":".$minutes;
+            return $toTime;
+        }
+        
+        return 0;
+    }
+
     public function model(array $row)
     {
+        $start_time     =  self::toTime($row['Mula Pada']);
+        $end_time       =  self::toTime($row['Akhir Pada']);
+
         return new Schedule([
             'user_id'           => $this->user_id,
             'child_id'          => $this->child_id,
             'day'               => $row['Nombor Hari'], 
-            'start_time'        => $row['Mula Pada'], 
-            'end_time'          => $row['Akhir Pada'], 
+            'start_time'        => $start_time,
+            'end_time'          => $end_time,
             'name'              => $row['Nama Kelas'],
             'class_url'         => $row['Link Kelas']
         ]);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/51684075/105946246-dbe2b100-60a1-11eb-9e96-c3b1a2903fe2.png)

Red box: Wrong format, imported time will become 00:00, the parent can manually update the time
Green box: Correct format, imported time will follow from excel